### PR TITLE
Add smoke export tests

### DIFF
--- a/tests/test_smoke_exports.py
+++ b/tests/test_smoke_exports.py
@@ -1,0 +1,27 @@
+def test_smoke_exports():
+    import importlib
+    import inspect
+
+    # gaps -> GapDetector
+    try:
+        gaps = importlib.import_module('probe.analysis.gaps')
+    except Exception as e:
+        raise AssertionError(f"Failed to import probe.analysis.gaps: {e}")
+    assert hasattr(gaps, 'GapDetector'), f"GapDetector not found in probe.analysis.gaps: {dir(gaps)}"
+    assert inspect.isclass(getattr(gaps, 'GapDetector'))
+
+    # seed_generator -> SeedGenerator
+    try:
+        sg = importlib.import_module('probe.analysis.seed_generator')
+    except Exception as e:
+        raise AssertionError(f"Failed to import probe.analysis.seed_generator: {e}")
+    assert hasattr(sg, 'SeedGenerator'), f"SeedGenerator not found: {dir(sg)}"
+    assert inspect.isclass(getattr(sg, 'SeedGenerator'))
+
+    # investigator imports without raising
+    try:
+        inv = importlib.import_module('probe.analysis.investigator')
+    except Exception as e:
+        raise AssertionError(f"Failed to import probe.analysis.investigator: {e}")
+    # Investigator should be a class in the module
+    assert hasattr(inv, 'Investigator') and inspect.isclass(getattr(inv, 'Investigator'))


### PR DESCRIPTION
Adds a small smoke test to assert that GapDetector, SeedGenerator and Investigator are importable and exported correctly. This helps catch import/export regressions earlier in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a smoke test that imports probe.analysis.gaps, probe.analysis.seed_generator, and probe.analysis.investigator and asserts GapDetector, SeedGenerator, and Investigator are exported classes. This catches import/export regressions early in CI.

<sup>Written for commit dc955983b2941435df5dc6b8cfdd5816fed9d8c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

