### PR TITLE
chore(release): bump version to 0.1.1 and add v0.4.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [v0.4.1] - 2026-01-11
+
+### Added (v0.4.1)
+
+- Research/CI: added and validated an opt-in scheduled/manual real-network integration workflow (`.github/workflows/research-integration.yml`) that safely skips when the test file or token is not present; run with `RUN_REAL_NET_TESTS=true` to exercise the test.
+- Added `probe/crawl/fetcher_adapter.py` and `tests/test_crawler_integration.py` (opt-in) to validate real-network crawling behavior.
+
 ## [v0.4] - 2026-01-09
 
 ### Added (v0.4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "probe"
-version = "0.1.0"
+version = "0.1.1"
 description = "Probe: A Deep Research Engine"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR bumps package version to 0.1.1 and adds a short changelog entry for v0.4.1 (real-network integration test + FetcherAdapter).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps version to 0.1.1 and adds the v0.4.1 changelog documenting the opt-in real-network integration workflow and the FetcherAdapter with an integration test. The workflow safely skips when credentials are missing and can be enabled with RUN_REAL_NET_TESTS=true.

<sup>Written for commit 2da6449f6428d3aeabdc5583e71aaa0184d16811. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

