### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased] - TBD
+
+### Added (unreleased)
+
+- Placeholder: prepare release v0.4.2
+
 ## [v0.4.1] - 2026-01-11
 
 ### Added (v0.4.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "probe"
-version = "0.4.1"
+version = "0.4.2"
 description = "Probe: A Deep Research Engine"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump package version to 0.4.2 and add Unreleased changelog placeholder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped package version to 0.4.2 and added an Unreleased section to the changelog to prepare the next release. No functional changes.

<sup>Written for commit e0ffa29f4b7f76a15fc74c117c2ec6f16bfa49da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

