### PR TITLE
tests: GapDetector unit tests

### DIFF
--- a/tests/test_gap_detector.py
+++ b/tests/test_gap_detector.py
@@ -71,18 +71,14 @@ def test_analyze_entity_gaps_detects_missing_types_and_confidence():
 
 
 def test_analyze_entity_gaps_fallback_to_documents():
-    # Map without get_entity_document_types but has get_entity_documents
-    class PartialMap(FakeMap):
+    # Simulate an older Map implementation that only provides get_entity_documents
+    class PartialMapNoTypes(FakeMap):
         def __init__(self):
             super().__init__(entity_present=True, doc_types=["report"], confidence=0.5, doc_count=1)
 
-        def get_entity_document_types(self, name):
-            # Simulate absence by raising AttributeError
-            raise AttributeError
+        # intentionally do NOT implement get_entity_document_types
 
-    m = PartialMap()
-    # remove attribute to simulate older Map
-    delattr(m, "get_entity_document_types")
+    m = PartialMapNoTypes()
     gd = GapDetector(m)
 
     out = gd.analyze_entity_gaps("exists", ["report", "datasheet"])


### PR DESCRIPTION
Add unit tests for GapDetector covering missing-entity, missing types detection, and Map fallbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for GapDetector covering entity-absent handling, missing document type detection with confidence/weak flag, and fallback to get_entity_documents when type API is unavailable. Tests also assert suggested domains and document count to prevent regressions.

<sup>Written for commit 6e52f16fbb237490cd47df2836aea1e5bb4b16f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

