### PR TITLE
Investigator: ingest feedback increments domain document counts

### DIFF
--- a/tests/test_investigator_ingest_feedback.py
+++ b/tests/test_investigator_ingest_feedback.py
@@ -35,7 +35,8 @@ def test_investigator_ingest_increments_domain_docs(tmp_path, monkeypatch):
     monkeypatch.setattr('probe.crawl.ingest.ingest_fetch_result', fake_ingest)
 
     inv = Investigator(m, ingest_on_fetch=True)
-    res = inv.investigate("E1", ["manual", "datasheet"], max_seeds=5, dry_run=False)
+    # limit to 1 seed so we increment documents_found by exactly 1
+    res = inv.investigate("E1", ["manual", "datasheet"], max_seeds=1, dry_run=False)
 
     dom_after = m.get_domain("high.example.com")
     assert dom_after.documents_found == before + 1


### PR DESCRIPTION
Add Map.increment_domain_documents helper and a test verifying Investigator increments domain document counts when ingests discover documents. Tests pass locally: 132 passed, 3 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure domain document counts increase when Investigator ingests a new document. Adds Map.increment_domain_documents and a test that limits seeds to verify a +1 increment.

- **Bug Fixes**
  - Investigator updates domain.documents_found on successful ingest via Map.increment_domain_documents.
  - Added unit test with mocked fetch/ingest to assert the count increases by 1.

<sup>Written for commit c8ee168fd6ee3393667c5d19c0ea8ee9f58f76f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

