### PR TITLE
ci(mypy): add types-PyYAML & make scripts a package to fix mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install tools
         run: |
           pip install --upgrade pip
-          pip install ruff mypy pre-commit black==25.12.0 isort==7.0.0
+          pip install ruff mypy pre-commit black==25.12.0 isort==7.0.0 types-PyYAML
 
       - name: Run formatters (black + isort)
         run: |

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Scripts package initializer.
+
+This file makes the `scripts` folder an importable package so mypy
+resolves module names consistently (avoids duplicate module name errors).
+"""


### PR DESCRIPTION
Install types-PyYAML in the lint job so mypy finds YAML stubs, and add scripts/__init__.py so the scripts module is consistently named (fixes duplicate source module error).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mypy failures by installing types-PyYAML in the lint workflow and making scripts a package. This resolves missing YAML type stubs and duplicate module name errors.

<sup>Written for commit 0173d3432c8b961503726df2cfe2261ff28fd7c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

