### PR TITLE
docs: add Educational Openness note to SCOPE

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -82,6 +82,8 @@
 
 **Success Criteria:** Can run full investigation, map accumulates knowledge
 
+> **Note — Educational Openness:** Add support for an **"Educational Openness"** mode (e.g., `Mode.educational_open`) that relaxes some gating for research and educational use-cases to enable broader exploration and transparency. This mode must include clear disclaimers, logging, and opt-in administrative enablement, and **is not intended** as the default for production deployments.
+
 ---
 
 ## v0.6 — Embeddings (Optional for v1)


### PR DESCRIPTION
Adds a short note to v0.5 about Mode.educational_open and requirements (disclaimer, logging, admin opt-in).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “Educational Openness” note to SCOPE v0.5 documenting Mode.educational_open for research and educational use. It clarifies required disclaimers, logging, and admin opt-in, and that this mode is not the production default.

<sup>Written for commit 940de5e97e0406b0364c50b8fc67d84e130ea84d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

