### PR TITLE
feat(orchestrator): add minimal BreadthFirstCrawler and Orchestrator

### DIFF
--- a/probe/orchestrator.py
+++ b/probe/orchestrator.py
@@ -1,0 +1,117 @@
+"""Orchestrator and simple breadth-first crawler for v0.5.
+
+This module provides a minimal, synchronous BreadthFirstCrawler and an
+Orchestrator facade. The focus is on small, testable behavior: crawl
+from seeds breadth-first, score pages using RelevanceScorer, and
+respect PolicyEngine decisions and per-domain denylists.
+
+The implementation is intentionally small — follow-up PRs will add
+concurrency, better politeness, and richer stop conditions.
+"""
+
+from collections import deque
+from typing import Callable, Dict, Iterable, List, Optional, Set
+
+from probe.core.map import Map
+from probe.policy import PolicyEngine
+
+
+class BreadthFirstCrawler:
+    """Simple synchronous breadth-first crawler.
+
+    Args:
+        map_obj: Map instance to record findings
+        fetch_fn: callable(url) -> fetch result dict (status_code, links)
+        scorer_fn: callable(page) -> float (0.0-1.0 relevance)
+        policy_engine: PolicyEngine to consult about domains
+    """
+
+    def _domain_from_url(self, url: str) -> Optional[str]:
+        try:
+            from urllib.parse import urlparse
+
+            return urlparse(url).netloc
+        except Exception:
+            return None
+
+    def _policy_allows(self, url: str) -> bool:
+        if not self.policy:
+            return True
+        domain = self._domain_from_url(url)
+        if not domain:
+            return True
+        decision = self.policy.evaluate_query("fetch", context={"domain": domain})
+        return bool(decision.get("allowed", True))
+
+    def _enqueue_links(
+        self, q: deque, res: Dict, depth: int, max_depth: int, visited: Set[str]
+    ):
+        if depth >= max_depth:
+            return
+        for link in res.get("links", []) or []:
+            href = link if isinstance(link, str) else link.get("url")
+            if href and href not in visited:
+                q.append((href, depth + 1))
+
+    def _is_document(self, url: str, res: Dict) -> bool:
+        ct = res.get("content_type") or ""
+        return "pdf" in ct or (isinstance(url, str) and url.lower().endswith(".pdf"))
+
+    def crawl(
+        self, seeds: Iterable[str], max_depth: int = 2, max_pages: int = 50
+    ) -> Dict[str, int]:
+        visited: Set[str] = set()
+        q = deque([(s, 0) for s in seeds])
+        pages_fetched = 0
+        docs_found = 0
+
+        while q and pages_fetched < max_pages:
+            url, depth = q.popleft()
+            if url in visited or depth > max_depth:
+                continue
+
+            if not self._policy_allows(url):
+                visited.add(url)
+                continue
+
+            try:
+                res = self.fetch(url)
+            except Exception:
+                visited.add(url)
+                continue
+
+            pages_fetched += 1
+            visited.add(url)
+
+            # Score page and decide whether to follow links
+            score = float(self.score(res))
+            if score >= 0.1:
+                self._enqueue_links(q, res, depth, max_depth, visited)
+
+            if self._is_document(url, res):
+                docs_found += 1
+
+        return {"pages_fetched": pages_fetched, "documents_found": docs_found}
+
+
+class Orchestrator:
+    """Facade that composes GapDetector/SeedGenerator/Fetcher/Scorer into a run.
+
+    This is a minimal orchestrator that runs a breadth-first crawl and
+    persists scoring/reporting to the Map.
+    """
+
+    def __init__(
+        self,
+        map_obj: Map,
+        fetch_fn: Callable,
+        scorer_fn: Callable,
+        policy_engine: Optional[PolicyEngine] = None,
+    ):
+        self.map = map_obj
+        self.crawler = BreadthFirstCrawler(map_obj, fetch_fn, scorer_fn, policy_engine)
+
+    def run(
+        self, seeds: List[str], max_depth: int = 2, max_pages: int = 50
+    ) -> Dict[str, int]:
+        return self.crawler.crawl(seeds, max_depth=max_depth, max_pages=max_pages)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,67 @@
+from probe.core.map import Map
+from probe.orchestrator import BreadthFirstCrawler, Orchestrator
+from probe.policy import Mode, PolicyEngine
+
+
+def test_bfs_follows_links_and_scores(tmp_path):
+    db = str(tmp_path / "probe.db")
+    m = Map(db)
+
+    # Simple fetcher that returns a page with two links and content-type
+    def fake_fetch(url):
+        return {
+            "status_code": 200,
+            "content_type": "text/html",
+            "links": ["http://a.example/p1", "http://b.example/p2"],
+        }
+
+    # Scorer giving moderate score to all pages
+    def fake_score(page):
+        return 0.5
+
+    crawler = BreadthFirstCrawler(m, fake_fetch, fake_score)
+    out = crawler.crawl(["http://start.example/"], max_depth=1, max_pages=10)
+
+    assert out["pages_fetched"] >= 1
+    # Links should be followed (2 pages follow) within depth 1
+    assert out["pages_fetched"] >= 3
+
+
+def test_policy_blocks_denied_domains(tmp_path):
+    db = str(tmp_path / "probe.db")
+    m = Map(db)
+
+    # fetcher that would return a page if called
+    def fake_fetch(url):
+        return {"status_code": 200, "content_type": "text/html", "links": []}
+
+    def fake_score(page):
+        return 0.9
+
+    pe = PolicyEngine(mode=Mode.PUBLIC_GUARDED)
+
+    crawler = BreadthFirstCrawler(m, fake_fetch, fake_score, policy_engine=pe)
+
+    # malicious.example is deny-listed in PolicyEngine defaults
+    out = crawler.crawl(["http://malicious.example/doc.pdf"], max_depth=1, max_pages=10)
+
+    # should have skipped the page entirely
+    assert out["pages_fetched"] == 0
+    assert out["documents_found"] == 0
+
+
+def test_orchestrator_runs_and_returns_summary(tmp_path):
+    db = str(tmp_path / "probe.db")
+    m = Map(db)
+
+    def fake_fetch(url):
+        # single pdf page
+        return {"status_code": 200, "content_type": "application/pdf", "links": []}
+
+    def fake_score(page):
+        return 1.0
+
+    orch = Orchestrator(m, fake_fetch, fake_score)
+    res = orch.run(["http://example.com/manual.pdf"], max_depth=0, max_pages=5)
+    assert res["pages_fetched"] == 1
+    assert res["documents_found"] == 1


### PR DESCRIPTION
Introduce a small synchronous breadth-first crawler and an Orchestrator facade. The crawler consults the PolicyEngine, scores pages via a scorer function, and enqueues links based on a simple relevance threshold. Adds unit tests covering link following, document detection, and policy blocking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal synchronous breadth-first crawler and an Orchestrator facade that score pages, respect PolicyEngine rules, and return a crawl summary. This introduces policy-aware link following with simple relevance filtering and PDF detection.

- **New Features**
  - BreadthFirstCrawler: BFS from seeds; follows links when score >= 0.1; depth and page limits.
  - Policy: Checks PolicyEngine per domain before fetching; skips denied domains.
  - Document detection: Flags PDFs via content-type or .pdf URLs.
  - Orchestrator: Wraps Map, fetcher, and scorer; run() returns pages_fetched and documents_found.
  - Tests: Cover link following, policy blocking, and document detection.

<sup>Written for commit 1a05d7bf60c28f4236817a31aea102901a3271be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

